### PR TITLE
 BUG: GameLog no longer displays current date, but rather date of game

### DIFF
--- a/client/src/components/GameLogs.vue
+++ b/client/src/components/GameLogs.vue
@@ -72,8 +72,8 @@
       this.getAllGames()
     },
     methods: {
-      moment: function () {
-        return moment();
+      moment: function (date) {
+        return moment(date);
       },
       async getAllGames () {
         const response = await GameLogsService.fetchGames()

--- a/client/src/services/BattleEngine.js
+++ b/client/src/services/BattleEngine.js
@@ -1,4 +1,5 @@
 import GameLogsService from '@/services/GameLogsService'
+import moment from 'moment'
 
 function playerChoice(){
   return Math.floor(Math.random() * 3);
@@ -18,7 +19,7 @@ const battle = (player1, player2) => {
   let outcome = (3 + p1Throws - p2Throws) % 3;
   let winner = ["Tie!", player1, player2][outcome];
   let game = {
-    date: new Date(),
+    date: moment(),
     playerOne: player1,
     playerTwo: player2,
     throwOne: choiceName(p1Throws),


### PR DESCRIPTION
When calling moment it wasn't setting moment to the date of the game since we were't doing anything with the parameter we were passing in. Now we pass in the game date, and the moment function actually receives it and sets the moment date to the date of the one passed in.