### PR TITLE
WIP: Creating Leaderboards

### DIFF
--- a/client/src/components/Landing.vue
+++ b/client/src/components/Landing.vue
@@ -97,6 +97,7 @@
     data() {
       return {
         data: [],
+        playerMap: [],
         nameOne: '',
         nameTwo: '',
         playerOne: null,
@@ -151,13 +152,14 @@
     },
     methods: {
       playGame() {
-        this.gameResults = battle(this.playerOne, this.playerTwo)
+        this.gameResults = battle(this.playerMap[0][1], this.playerMap[1][1])
       },
       async getPlayers() {
         const response = await PlayerService.fetchPlayers()
         let obj = response.data.players
         Object.keys(obj).forEach(key => {
           this.data.push(obj[key].name)
+          this.playerMap.push([obj[key].name, obj[key]._id])
         })
       }
     }

--- a/client/src/components/Leaderboard.vue
+++ b/client/src/components/Leaderboard.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="players">
+    <section class="hero">
+      <div class="hero-body">
+        <div class="container has-text-centered">
+          <h1 class="title">
+            Leaderboard
+          </h1>
+          <h2 class="subtitle">
+            Leaderboard of all Roshambo Players
+          </h2>
+        </div>
+      </div>
+    </section>
+
+    <div v-if="leaderboard && leaderboard.length > 0">
+      <div class="columns is-centered">
+        <div class="column is-half">
+          <table class="table is-bordered is-narrow is-hoverable is-fullwidth">
+            <thead>
+            <tr>
+              <th>Player</th>
+              <th>Wins</th>
+              <th>Loses</th>
+              <th>Conquerer</th>
+              <th>Nemesis</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr v-for="record in leaderboard">
+              <td>{{ record.player }}</td>
+              <td>{{ record.wins }}</td>
+              <td>{{ record.loses }}</td>
+              <td>{{ record.conquerer }}</td>
+              <td>{{ record.nemesis }}</td>
+            </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div v-else>
+      <div class="columns is-centered">
+        <div class="column is-4">
+          <div class="card">
+            <div class="card-image">
+              <figure class="image">
+                <img src="../assets/images/nothing2see.gif" alt="Nothing Here">
+              </figure>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+  import LeaderboardService from '@/services/LeaderboardService'
+  export default {
+    name: 'Leaderboard',
+    data () {
+      return {
+        games: [],
+        errors: []
+      }
+    },
+    mounted () {
+      this.getLeaderboard()
+    },
+    methods: {
+      async getLeaderboard () {
+        const response = await LeaderboardService.getLeaderboard()
+        this.games = response.data.leaderboard
+      }
+    }
+  }
+</script>
+
+<style>
+  .rc {
+    border-radius: 25px !important;
+  }
+</style>

--- a/client/src/components/Leaderboard.vue
+++ b/client/src/components/Leaderboard.vue
@@ -61,17 +61,20 @@
     name: 'Leaderboard',
     data () {
       return {
-        games: [],
+        leaderboard: [],
         errors: []
       }
     },
     mounted () {
-      this.getLeaderboard()
+      this.fetchLeaderboard()
     },
     methods: {
-      async getLeaderboard () {
-        const response = await LeaderboardService.getLeaderboard()
-        this.games = response.data.leaderboard
+      async fetchLeaderboard () {
+        const response = await LeaderboardService.fetchLeaderboard()
+        response.data.leaderboard.sort(function (playerOne, playerTwo) {
+          return playerTwo.wins - playerOne.wins
+        });
+        this.leaderboard = response.data.leaderboard
       }
     }
   }

--- a/client/src/components/Leaderboard.vue
+++ b/client/src/components/Leaderboard.vue
@@ -30,7 +30,7 @@
             <tr v-for="record in leaderboard">
               <td>{{ record.player }}</td>
               <td>{{ record.wins }}</td>
-              <td>{{ record.loses }}</td>
+              <td>{{ record.losses }}</td>
               <td>{{ record.conquerer }}</td>
               <td>{{ record.nemesis }}</td>
             </tr>

--- a/client/src/components/Leaderboard.vue
+++ b/client/src/components/Leaderboard.vue
@@ -31,8 +31,8 @@
               <td>{{ record.player }}</td>
               <td>{{ record.wins }}</td>
               <td>{{ record.losses }}</td>
-              <td>{{ record.conquerer }}</td>
-              <td>{{ record.nemesis }}</td>
+              <td>{{ record.conquerer ? record.conquerer : "Unkown" }}</td>
+              <td>{{ record.nemesis ? record.nemesis : "Unkown" }}</td>
             </tr>
             </tbody>
           </table>

--- a/client/src/components/Navigation.vue
+++ b/client/src/components/Navigation.vue
@@ -13,11 +13,11 @@
 
     <div id="navbarExampleTransparentExample" class="navbar-menu">
       <div class="navbar-start">
-        <router-link v-bind:to="{ name: 'GameLogs' }" class="navbar-item" active-class="link-is-active">
-           <span class="icon">
-              <i class="fas fa-chart-line"></i>
-           </span>
-          <span>Game Logs</span>
+        <router-link v-bind:to="{ name: 'Landing' }" class="navbar-item" active-class="link-is-active" exact>
+          <span class="icon">
+            <i class="fas fa-hand-scissors"></i>
+          </span>
+          <span>Fight!</span>
         </router-link>
         <router-link v-bind:to="{ name: 'Players' }" class="navbar-item" active-class="link-is-active">
           <span class="icon">
@@ -25,11 +25,17 @@
           </span>
           <span>Players</span>
         </router-link>
-        <router-link v-bind:to="{ name: 'Landing' }" class="navbar-item" active-class="link-is-active" exact>
-          <span class="icon">
-            <i class="fas fa-hand-scissors"></i>
-          </span>
-          <span>Fight!</span>
+        <router-link v-bind:to="{ name: 'GameLogs' }" class="navbar-item" active-class="link-is-active">
+           <span class="icon">
+              <i class="fas fa-calendar-alt"></i>
+           </span>
+          <span>Game Logs</span>
+        </router-link>
+        <router-link v-bind:to="{ name: 'Leaderboard' }" class="navbar-item" active-class="link-is-active">
+           <span class="icon">
+              <i class="fas fa-chart-bar"></i>
+           </span>
+          <span>Leaderboard</span>
         </router-link>
       </div>
 

--- a/client/src/components/PlayerProfile.vue
+++ b/client/src/components/PlayerProfile.vue
@@ -3,7 +3,7 @@
     <div class="hero-body">
       <div class="container">
         <div class="columns">
-          <div class="column is-4">
+          <div class="column is-3">
             <div class="card">
               <header class="card-header">
                 <p class="card-header-title is-centered">
@@ -32,6 +32,49 @@
               </div>
             </div>
           </div>
+          <div class="column is-7">
+            <div v-if="games && games.length > 0">
+              <div class="columns is-left">
+                <div class="column is-half">
+                  <table class="table is-bordered is-narrow is-hoverable is-fullwidth">
+                    <thead>
+                    <tr>
+                      <th>Date</th>
+                      <th>Player One</th>
+                      <th>Player Two</th>
+                      <th>Player One Throw</th>
+                      <th>Player Two Throw</th>
+                      <th>Winner</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr v-for="game in games">
+                      <td>{{ moment(game.date).format('dddd, MMMM Do YYYY, h:mm a') }}</td>
+                      <td>{{ game.playerOne }}</td>
+                      <td>{{ game.playerTwo }}</td>
+                      <td>{{ game.playerOneThrew }}</td>
+                      <td>{{ game.playerTwoThrew }}</td>
+                      <td>{{ game.winner }}</td>
+                    </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+            <div v-else>
+              <div class="columns is-centered">
+                <div class="column is-4">
+                  <div class="card">
+                    <div class="card-image">
+                      <figure class="image">
+                        <img src="../assets/images/nothing2see.gif" alt="Nothing Here">
+                      </figure>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -41,6 +84,7 @@
 <script>
   import PlayerService from '@/services/PlayerService'
   import GameLogsService from '@/services/GameLogsService'
+  import moment from 'moment'
 
   export default {
     name: 'PlayerProfile',
@@ -58,6 +102,9 @@
       this.getPlayerGames()
     },
     methods: {
+      moment: function (date) {
+        return moment(date);
+      },
       async getPlayer () {
         const response = await PlayerService.getPlayer({
           id: this.$route.params.id
@@ -70,7 +117,8 @@
         const response = await GameLogsService.getPlayerGames({
           id: this.$route.params.id
         })
-        this.games = response.data.gamelogs
+        this.games = response.data
+        console.log(this.games)
       }
     }
   }

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -6,6 +6,7 @@ import Players from '@/components/Players'
 import GameLogs from '@/components/GameLogs'
 import EditPlayer from '@/components/EditPlayer'
 import PlayerProfile from '@/components/PlayerProfile'
+import Leaderboard from '@/components/Leaderboard'
 
 Vue.use(Router)
 
@@ -18,29 +19,34 @@ export default new Router({
       component: Landing
     },
     {
-      path: '/New-Player',
+      path: '/newplayer',
       name: 'NewPlayer',
       component: NewPlayer
     },
     {
-      path: '/Players',
+      path: '/players',
       name: 'Players',
       component: Players
     },
     {
-      path: '/GameLogs',
+      path: '/gamelogs',
       name: 'GameLogs',
       component: GameLogs
     },
     {
-      path: '/player/:id',
-      name: 'EditPlayer',
-      component: EditPlayer
+      path: '/leaderboard',
+      name: 'Leaderboard',
+      component: Leaderboard
     },
     {
-      path: '/player/:id/profile',
+      path: '/player/:id',
       name: 'PlayerProfile',
       component: PlayerProfile
+    },
+    {
+      path: '/player/:id/edit',
+      name: 'EditPlayer',
+      component: EditPlayer
     }
   ]
 })

--- a/client/src/services/BattleEngine.js
+++ b/client/src/services/BattleEngine.js
@@ -35,7 +35,7 @@ const battle = (player1, player2) => {
     winner,
     p1Throws: choiceName(p1Throws),
     p2Throws: choiceName(p2Throws)
-  };
+  }
 }
 
 export default battle;

--- a/client/src/services/BattleEngine.js
+++ b/client/src/services/BattleEngine.js
@@ -28,16 +28,14 @@ const battle = (player1, player2) => {
     winner: winner
   }
 
-  let battle = {
+  GameLogsService.addGame(game);
+  LeaderboardService.updateLeaderboards(game);
+
+  return {
     winner,
     p1Throws: choiceName(p1Throws),
     p2Throws: choiceName(p2Throws)
-  }
-
-  GameLogsService.addGame(game);
-  LeaderboardService.updateLeaderboards(battle);
-
-  return battle;
+  };
 }
 
 export default battle;

--- a/client/src/services/BattleEngine.js
+++ b/client/src/services/BattleEngine.js
@@ -1,4 +1,5 @@
 import GameLogsService from '@/services/GameLogsService'
+import LeaderboardService from '@/services/LeaderboardService'
 import moment from 'moment'
 
 function playerChoice(){
@@ -27,13 +28,16 @@ const battle = (player1, player2) => {
     winner: winner
   }
 
-  GameLogsService.addGame(game);
-
-  return {
+  let battle = {
     winner,
     p1Throws: choiceName(p1Throws),
     p2Throws: choiceName(p2Throws)
   }
+
+  GameLogsService.addGame(game);
+  LeaderboardService.updateLeaderboards(battle);
+
+  return battle;
 }
 
 export default battle;

--- a/client/src/services/LeaderboardService.js
+++ b/client/src/services/LeaderboardService.js
@@ -1,4 +1,21 @@
 import Api from '@/services/Api'
+import GameLogsService from '@/services/GameLogsService'
+
+function getNemesis(logs) {
+  return null
+}
+
+function getConquerer(logs) {
+  return null
+}
+
+function updateUserLeaderboardData(record, id) {
+  logs = GameLogsService.getPlayerGames(id)
+  record.nemesis = getNemesis(logs)
+  record.conquerer = getConquerer(logs)
+  return record
+}
+
 
 export default {
   fetchLeaderboard() {
@@ -10,7 +27,7 @@ export default {
   },
 
   createPlayerLeaderboard(params) {
-    return Api().get('leaderboard/player/' + params.id)
+    return Api().post('leaderboard/player/' + params.id)
   },
 
   updateLeaderboards(battle) {
@@ -31,6 +48,10 @@ export default {
       playerTwoRecord.losses++
     }
 
+    playerOneRecord = updateUserLeaderboardData(playerOneRecord, battle.playerOne)
+    playerTwoRecord = updateUserLeaderboardData(playerTwoRecord, battle.playerTwo)
 
+    Api().put('leaderboard/player/' + battle.playerOne, { leaderboard: playerOneRecord})
+    Api().put('leaderboard/player/' + battle.playerTwo, { leaderboard: playerTwoRecord})
   }
 }

--- a/client/src/services/LeaderboardService.js
+++ b/client/src/services/LeaderboardService.js
@@ -1,0 +1,11 @@
+import Api from '@/services/Api'
+
+export default {
+  fetchLeaderboard() {
+    return Api().get('leaderboard')
+  },
+
+  getPlayerLeaderboard(params) {
+    return Api().get('leaderboard/player/' + params.id)
+  }
+}

--- a/client/src/services/LeaderboardService.js
+++ b/client/src/services/LeaderboardService.js
@@ -7,5 +7,30 @@ export default {
 
   getPlayerLeaderboard(params) {
     return Api().get('leaderboard/player/' + params.id)
+  },
+
+  createPlayerLeaderboard(params) {
+    return Api().get('leaderboard/player/' + params.id)
+  },
+
+  updateLeaderboards(battle) {
+    playerOneRecord = getPlayerLeaderboard(battle.playerOne)
+    playerTwoRecord = getPlayerLeaderboard(battle.playerTwo)
+
+    winner = battle.winner
+
+    if (winner == battle.playerOne) {
+      playerOneRecord.wins++
+    } else {
+      playerTwoRecord.wins++
+    }
+
+    if (winner != battle.playerOne) {
+      playerOneRecord.losses++
+    } else {
+      playerTwoRecord.losses++
+    }
+
+
   }
 }

--- a/client/src/services/LeaderboardService.js
+++ b/client/src/services/LeaderboardService.js
@@ -16,42 +16,51 @@ function updateUserLeaderboardData(record, id) {
   return record
 }
 
+function getPlayerLeaderboard(params) {
+  return Api().get('leaderboard/player/' + params.id)
+}
+
+function fetchLeaderboard() {
+  return Api().get('leaderboard')
+}
+
+function createPlayerLeaderboard(params) {
+  return Api().post('leaderboard/player/' + params.id)
+}
+
+function updateLeaderboards(battle) {
+  getPlayerLeaderboard({id: battle.playerOne}).then(function(data) {
+    playerOneRecord = data.data
+  })
+
+  getPlayerLeaderboard({id: battle.playerTwo}).then(function(data) {
+    playerTwoRecord = data.data
+  })
+
+  winner = battle.winner
+
+  if (winner == battle.playerOne) {
+    playerOneRecord.wins++
+  } else {
+    playerTwoRecord.wins++
+  }
+
+  if (winner != battle.playerOne) {
+    playerOneRecord.losses++
+  } else {
+    playerTwoRecord.losses++
+  }
+
+  playerOneRecord = updateUserLeaderboardData(playerOneRecord, battle.playerOne)
+  playerTwoRecord = updateUserLeaderboardData(playerTwoRecord, battle.playerTwo)
+
+  Api().put('leaderboard/player/' + battle.playerOne, { leaderboard: playerOneRecord})
+  Api().put('leaderboard/player/' + battle.playerTwo, { leaderboard: playerTwoRecord})
+}
 
 export default {
-  fetchLeaderboard() {
-    return Api().get('leaderboard')
-  },
-
-  getPlayerLeaderboard(params) {
-    return Api().get('leaderboard/player/' + params.id)
-  },
-
-  createPlayerLeaderboard(params) {
-    return Api().post('leaderboard/player/' + params.id)
-  },
-
-  updateLeaderboards(battle) {
-    playerOneRecord = getPlayerLeaderboard(battle.playerOne)
-    playerTwoRecord = getPlayerLeaderboard(battle.playerTwo)
-
-    winner = battle.winner
-
-    if (winner == battle.playerOne) {
-      playerOneRecord.wins++
-    } else {
-      playerTwoRecord.wins++
-    }
-
-    if (winner != battle.playerOne) {
-      playerOneRecord.losses++
-    } else {
-      playerTwoRecord.losses++
-    }
-
-    playerOneRecord = updateUserLeaderboardData(playerOneRecord, battle.playerOne)
-    playerTwoRecord = updateUserLeaderboardData(playerTwoRecord, battle.playerTwo)
-
-    Api().put('leaderboard/player/' + battle.playerOne, { leaderboard: playerOneRecord})
-    Api().put('leaderboard/player/' + battle.playerTwo, { leaderboard: playerTwoRecord})
-  }
+  fetchLeaderboard,
+  getPlayerLeaderboard,
+  createPlayerLeaderboard,
+  updateLeaderboards
 }

--- a/client/src/services/PlayerService.js
+++ b/client/src/services/PlayerService.js
@@ -7,8 +7,9 @@ export default {
   },
 
   addPlayer(params) {
-    LeaderboardService.createPlayerLeaderBoard(params);
-    return Api().post('players', params);
+    response = Api().post('players', params);
+    LeaderboardService.createPlayerLeaderBoard(response.id);
+    return response
   },
 
   getPlayer(params) {

--- a/client/src/services/PlayerService.js
+++ b/client/src/services/PlayerService.js
@@ -1,5 +1,4 @@
 import Api from '@/services/Api'
-import LeaderboardService from '@/services/LeaderboardService'
 
 export default {
   fetchPlayers() {

--- a/client/src/services/PlayerService.js
+++ b/client/src/services/PlayerService.js
@@ -7,9 +7,7 @@ export default {
   },
 
   addPlayer(params) {
-    response = Api().post('players', params);
-    LeaderboardService.createPlayerLeaderBoard(response.id);
-    return response
+    return Api().post('players', params);
   },
 
   getPlayer(params) {

--- a/client/src/services/PlayerService.js
+++ b/client/src/services/PlayerService.js
@@ -1,4 +1,5 @@
 import Api from '@/services/Api'
+import LeaderboardService from '@/services/LeaderboardService'
 
 export default {
   fetchPlayers() {
@@ -6,6 +7,7 @@ export default {
   },
 
   addPlayer(params) {
+    LeaderboardService.createPlayerLeaderBoard(params);
     return Api().post('players', params);
   },
 

--- a/server/models/gamelogs.js
+++ b/server/models/gamelogs.js
@@ -22,7 +22,12 @@ function fetchAll() {
 
 function fetchPlayerGames(id) {
     return new Promise((resolve, reject) => {
-        GameLogs.find({playerOne:id}, Object.keys(schema).join(" "), function (error, gameLogs) {
+        GameLogs.find({
+          $or:[
+              {playerOne:id},
+              {playerTwo:id}
+          ]}, Object.keys(schema).join(" "), function (error, gameLogs) {
+
             if (error) { reject(error); }
             resolve(gameLogs);
         })

--- a/server/models/gamelogs.js
+++ b/server/models/gamelogs.js
@@ -39,11 +39,12 @@ function addGame(date, playerOne, playerTwo, throwOne, throwTwo, winner) {
       winner: winner
     });
     return new Promise((resolve, reject) => {
-        new_game.save(function (error) {
+        new_game.save(function (error, gamelog) {
             if (error) {
                 reject(error);
             }
             resolve({
+                gamelog: gamelog,
                 success: true,
                 message: 'Game was recorded successfully!'
             });

--- a/server/models/leaderboard.js
+++ b/server/models/leaderboard.js
@@ -43,7 +43,7 @@ function fetchLeaderboard() {
 
 function fetchPlayerLeaderboard(id) {
     return new Promise((resolve, reject) => {
-        Leaderboard.find({player:id}, Object.keys(schema).join(" "), function (error, leaderboard) {
+        Leaderboard.find({player: id}, Object.keys(schema).join(" "), function (error, leaderboard) {
             if (error) { reject(error); }
             resolve(leaderboard);
         })

--- a/server/models/leaderboard.js
+++ b/server/models/leaderboard.js
@@ -19,11 +19,12 @@ function createPlayerLeaderBoard(id) {
         nemesis: null
     });
     return new Promise((resolve, reject) => {
-        new_leaderboard.save(function (error) {
+        new_leaderboard.save(function (error, leaderboard) {
             if (error) {
                 reject(error);
             }
             resolve({
+                leaderboard: leaderboard,
                 success: true,
                 message: 'Leaderboard record for user has been created'
             });
@@ -53,7 +54,7 @@ function fetchPlayerLeaderboard(id) {
     return new Promise((resolve, reject) => {
         Leaderboard.fetchPlayerLeaderboard(id, Object.keys(schema).join(" "), function (error, leaderboard) {
             if (error) {reject(error) }
-            
+
             leaderboard.wins = new_leaderboard.wins;
             leaderboard.losses = new_leaderboard.losses;
             leaderboard.nemesis = new_leaderboard.nemesis;

--- a/server/models/leaderboard.js
+++ b/server/models/leaderboard.js
@@ -3,12 +3,21 @@ const factory = require('./database.js');
 const schema = {
   player: String,
   wins: Number,
-  loses: Number,
+  losses: Number,
   conquerer: String,
   nemesis: String
 };
 
 const Leaderboard = factory("Leaderboard", schema);
+
+function createPlayerLeaderBoard() {
+    return new Promise((resolve, reject) => {
+        Leaderboard.find({}, Object.keys(schema).join(" "), function (error, leaderboard) {
+           if (error) { reject(error); }
+            resolve(leaderboard);
+        }).sort({_id:-1});
+    });
+}
 
 function fetchLeaderboard() {
     return new Promise((resolve, reject) => {
@@ -26,9 +35,28 @@ function fetchPlayerLeaderboard(id) {
             resolve(leaderboard);
         })
     });
+  }
+
+  function updatePlayerLeaderboard(id) {
+    return new Promise((resolve, reject) => {
+        Leaderboard.fetchPlayerLeaderboard(id, Object.keys(schema).join(" "), function (error, player) {
+            if (error) {reject(error) }
+
+            player.name = playerObj.name;
+            player.nickname = playerObj.nickname;
+            player.chant = playerObj.chant;
+
+            player.save(function (error) {
+                if (error) { reject(error); }
+                resolve(true);
+            });
+        });
+    });
 }
 
 module.exports = {
   fetchLeaderboard,
-  fetchPlayerLeaderboard
+  fetchPlayerLeaderboard,
+  updatePlayerLeaderboard,
+  createPlayerLeaderBoard
 };

--- a/server/models/leaderboard.js
+++ b/server/models/leaderboard.js
@@ -10,12 +10,24 @@ const schema = {
 
 const Leaderboard = factory("Leaderboard", schema);
 
-function createPlayerLeaderBoard() {
+function createPlayerLeaderBoard(id) {
+    let new_leaderboard = new Leaderboard({
+        player: id,
+        wins: 0,
+        losses: 0,
+        conquerer: null,
+        nemesis: null
+    });
     return new Promise((resolve, reject) => {
-        Leaderboard.find({}, Object.keys(schema).join(" "), function (error, leaderboard) {
-           if (error) { reject(error); }
-            resolve(leaderboard);
-        }).sort({_id:-1});
+        new_leaderboard.save(function (error) {
+            if (error) {
+                reject(error);
+            }
+            resolve({
+                success: true,
+                message: 'Leaderboard record for user has been created'
+            });
+        });
     });
 }
 
@@ -37,16 +49,17 @@ function fetchPlayerLeaderboard(id) {
     });
   }
 
-  function updatePlayerLeaderboard(id) {
+  function updatePlayerLeaderboard(id, new_leaderboard) {
     return new Promise((resolve, reject) => {
-        Leaderboard.fetchPlayerLeaderboard(id, Object.keys(schema).join(" "), function (error, player) {
+        Leaderboard.fetchPlayerLeaderboard(id, Object.keys(schema).join(" "), function (error, leaderboard) {
             if (error) {reject(error) }
+            
+            leaderboard.wins = new_leaderboard.wins;
+            leaderboard.losses = new_leaderboard.losses;
+            leaderboard.nemesis = new_leaderboard.nemesis;
+            leaderboard.conquerer = new_leaderboard.conquerer;
 
-            player.name = playerObj.name;
-            player.nickname = playerObj.nickname;
-            player.chant = playerObj.chant;
-
-            player.save(function (error) {
+            leaderboard.save(function (error) {
                 if (error) { reject(error); }
                 resolve(true);
             });

--- a/server/models/leaderboard.js
+++ b/server/models/leaderboard.js
@@ -1,0 +1,34 @@
+const factory = require('./database.js');
+
+const schema = {
+  player: String,
+  wins: Number,
+  loses: Number,
+  conquerer: String,
+  nemesis: String
+};
+
+const Leaderboard = factory("Leaderboard", schema);
+
+function fetchLeaderboard() {
+    return new Promise((resolve, reject) => {
+        Leaderboard.find({}, Object.keys(schema).join(" "), function (error, leaderboard) {
+           if (error) { reject(error); }
+            resolve(leaderboard);
+        }).sort({_id:-1})
+    });
+}
+
+function fetchPlayerLeaderboard(id) {
+    return new Promise((resolve, reject) => {
+        Leaderboard.find({player:id}, Object.keys(schema).join(" "), function (error, leaderboard) {
+            if (error) { reject(error); }
+            resolve(leaderboard);
+        })
+    });
+}
+
+module.exports = {
+  fetchLeaderboard,
+  fetchPlayerLeaderboard
+};

--- a/server/models/players.js
+++ b/server/models/players.js
@@ -33,11 +33,12 @@ function addPlayer(name, nickname, chant) {
         chant: chant
     });
     return new Promise((resolve, reject) => {
-        new_player.save(function (error) {
+        new_player.save(function (error, user) {
             if (error) {
                 reject(error);
             }
             resolve({
+                user: user,
                 success: true,
                 message: 'Player was saved successfully'
             });

--- a/server/routes/leaderboard.js
+++ b/server/routes/leaderboard.js
@@ -1,6 +1,19 @@
 let Leaderboard = require("../models/leaderboard");
 
 module.exports = (app) => {
+
+  // Add new player
+  app.post('/leaderboard/player/:id', (req, res) => {
+    Leaderboard.createPlayerLeaderboard(req.params.id).then(
+      (leaderboard) => {
+        res.send(leaderboard);
+      },
+      (err) => {
+        console.error(err);
+      }
+    );
+  });
+
   // Fetch all games
   app.get('/leaderboard', (req, res) => {
     Leaderboard.fetchLeaderboard().then(
@@ -16,6 +29,18 @@ module.exports = (app) => {
   // Fetch a single players game log
   app.get('/leaderboard/player/:id', (req, res) => {
     Leaderboard.fetchPlayerLeaderboard(req.params.id).then(
+      (leaderboard) => {
+        res.send(leaderboard);
+      },
+      (err) => {
+        console.error(err);
+      }
+    );
+  });
+
+  // Fetch a single players game log
+  app.put('/leaderboard/player/:id', (req, res) => {
+    Leaderboard.updatePlayerLeaderboard(req.params.id).then(
       (leaderboard) => {
         res.send(leaderboard);
       },

--- a/server/routes/leaderboard.js
+++ b/server/routes/leaderboard.js
@@ -2,7 +2,7 @@ let Leaderboard = require("../models/leaderboard");
 
 module.exports = (app) => {
 
-  // Add new player
+  // Create empty leaderboard record for user
   app.post('/leaderboard/player/:id', (req, res) => {
     Leaderboard.createPlayerLeaderboard(req.params.id).then(
       (leaderboard) => {
@@ -14,7 +14,7 @@ module.exports = (app) => {
     );
   });
 
-  // Fetch all games
+  // Fetch all leaderboards in the database
   app.get('/leaderboard', (req, res) => {
     Leaderboard.fetchLeaderboard().then(
       (leaderboard) => {
@@ -26,7 +26,7 @@ module.exports = (app) => {
     );
   });
 
-  // Fetch a single players game log
+  // Fetch the leaderboard data for one user
   app.get('/leaderboard/player/:id', (req, res) => {
     Leaderboard.fetchPlayerLeaderboard(req.params.id).then(
       (leaderboard) => {
@@ -38,9 +38,9 @@ module.exports = (app) => {
     );
   });
 
-  // Fetch a single players game log
+  // Update the leaderboard for a player
   app.put('/leaderboard/player/:id', (req, res) => {
-    Leaderboard.updatePlayerLeaderboard(req.params.id).then(
+    Leaderboard.updatePlayerLeaderboard(req.params.id, req.params.leaderboard).then(
       (leaderboard) => {
         res.send(leaderboard);
       },

--- a/server/routes/leaderboard.js
+++ b/server/routes/leaderboard.js
@@ -1,0 +1,27 @@
+let Leaderboard = require("../models/leaderboard");
+
+module.exports = (app) => {
+  // Fetch all games
+  app.get('/leaderboard', (req, res) => {
+    Leaderboard.fetchLeaderboard().then(
+      (leaderboard) => {
+        res.send({leaderboard: leaderboard});
+      },
+      (err) => {
+        console.error(err);
+      }
+    );
+  });
+
+  // Fetch a single players game log
+  app.get('/leaderboard/player/:id', (req, res) => {
+    Leaderboard.fetchPlayerLeaderboard(req.params.id).then(
+      (leaderboard) => {
+        res.send(leaderboard);
+      },
+      (err) => {
+        console.error(err);
+      }
+    );
+  });
+};

--- a/server/routes/players.js
+++ b/server/routes/players.js
@@ -1,10 +1,12 @@
 let Players = require("../models/players");
+let Leaderboard = require("../models/leaderboard");
 
 module.exports = (app) => {
   // Add new player
   app.post('/players', (req, res) => {
     Players.addPlayer(req.body.name, req.body.nickname, req.body.chant).then(
       (message) => {
+        Leaderboard.createPlayerLeaderBoard(message.user.id);
         res.send(message);
       },
       (err) => {

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -18,11 +18,10 @@ db.once("open", function(callback){
 });
 // END DATABASE SETUP
 
-let GameLogs = require("../models/gamelogs");
-
 // configure routes
 require("../routes/players")(app);
 require("../routes/gamelogs")(app);
+require("../routes/leaderboard")(app);
 
 // app.listen(process.env.PORT || 8081)
 


### PR DESCRIPTION
Major over haul for leader boards, with lots of other fun features:

I would like a lot of look at this, it's also a current work in progress and not everything is ironed out yet.

- Adding in Leaderboard service
- Battles now pass in user id instead of name for unique identifiers
- Create Leaderboard database model
- Create Leaderboard api endpoints (create, update, fetch all, fetch one)
- Updated battle service to now update leaderboard records on each game
- When creating a new member it adds a leaderboard record with 0 wins/loses and null nemesis/conquerer
- Added leaderboard nav item
- Reorganized nav items to potentially be more fluid looking
- Create a leaderboard view to show all leaderboards
- Updated routes to all be lowercase
- Switched players/:id to be the player profile and players/:id/edit to be the edit screen
- Database save requests now return the newly created record instead of just success comment
- Game logs find logs for user now works and is able to search whether user was playerOne or playerTwo
- Added in game logs into users profile