### PR TITLE
update player profile to display gamelog  names instead of ids

### DIFF
--- a/client/src/components/PlayerProfile.vue
+++ b/client/src/components/PlayerProfile.vue
@@ -34,32 +34,28 @@
           </div>
           <div class="column is-7">
             <div v-if="games && games.length > 0">
-              <div class="columns is-left">
-                <div class="column is-half">
-                  <table class="table is-bordered is-narrow is-hoverable is-fullwidth">
-                    <thead>
-                    <tr>
-                      <th>Date</th>
-                      <th>Player One</th>
-                      <th>Player Two</th>
-                      <th>Player One Throw</th>
-                      <th>Player Two Throw</th>
-                      <th>Winner</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr v-for="game in games">
-                      <td>{{ moment(game.date).format('dddd, MMMM Do YYYY, h:mm a') }}</td>
-                      <td>{{ game.playerOne }}</td>
-                      <td>{{ game.playerTwo }}</td>
-                      <td>{{ game.playerOneThrew }}</td>
-                      <td>{{ game.playerTwoThrew }}</td>
-                      <td>{{ game.winner }}</td>
-                    </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
+              <table class="table is-bordered is-narrow is-hoverable is-fullwidth">
+                <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Player One</th>
+                  <th>Player Two</th>
+                  <th>Player One Throw</th>
+                  <th>Player Two Throw</th>
+                  <th>Winner</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr v-for="game in games">
+                  <td>{{ moment(game.date).format('dddd, MMMM Do YYYY, h:mm a') }}</td>
+                  <td>{{ game.playerOne.name }}</td>
+                  <td>{{ game.playerTwo.name }}</td>
+                  <td>{{ game.playerOneThrew }}</td>
+                  <td>{{ game.playerTwoThrew }}</td>
+                  <td>{{ game.winner.name }}</td>
+                </tr>
+                </tbody>
+              </table>
             </div>
             <div v-else>
               <div class="columns is-centered">

--- a/server/models/gamelogs.js
+++ b/server/models/gamelogs.js
@@ -29,7 +29,7 @@ function fetchAll() {
         .populate('playerOne')
         .populate('playerTwo')
         .populate('winner')
-        .exec(function (error, gameLogs) {
+        .exec((error, gameLogs) => {
         if (error) { reject(error); }
         resolve(gameLogs);
       })
@@ -38,15 +38,21 @@ function fetchAll() {
 
 function fetchPlayerGames(id) {
     return new Promise((resolve, reject) => {
-        GameLogs.find({
-          $or:[
-              {playerOne:id},
-              {playerTwo:id}
-          ]}, Object.keys(schema).join(" "), function (error, gameLogs) {
-
-            if (error) { reject(error); }
-            resolve(gameLogs);
+      GameLogs.find({
+        $or:[
+          {playerOne:id},
+          {playerTwo:id}
+        ]})
+        .sort([['date', -1]])
+        .populate('playerOne')
+        .populate('playerTwo')
+        .populate('winner')
+        .exec((error, gameLogs) => {
+          if (error) { reject(error); }
+          resolve(gameLogs);
         })
+
+
     });
 }
 


### PR DESCRIPTION
#35 Updated the Gamelog on Player Profile to display players names instead of IDs. 

Will continue working on the UI for this, as it's been decided using Tables for game logs is not aesthetically pleasing.

Also.....



![](https://thumbs.gfycat.com/DampSpeedyHoiho-size_restricted.gif)